### PR TITLE
Added .Errors() functionality

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,1 @@
+package tf_test

--- a/tf_test.go
+++ b/tf_test.go
@@ -1,6 +1,7 @@
 package tf_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/elliotchance/tf"
@@ -23,6 +24,42 @@ func NewNil(o *Optional) string {
 func TestNil(t *testing.T) {
 	NewNil := tf.Function(t, NewNil)
 	NewNil(nil).Returns("default")
+}
+
+type CustomError struct {
+	err error
+}
+
+func (c CustomError) Error() string {
+	return c.err.Error()
+}
+
+func TestError(t *testing.T) {
+	t.Run("Catches basic error", func(t *testing.T) {
+		NewError := tf.Function(t, func() error {
+			return errors.New("some error")
+		})
+
+		NewError().Errors()
+	})
+
+	t.Run("Catches named error", func(t *testing.T) {
+		NewError := tf.Function(t, func() error {
+			return errors.New("some error")
+		})
+
+		NewError().Errors("some error")
+	})
+
+	t.Run("Catches particular class error", func(t *testing.T) {
+		custom := CustomError{errors.New("custom error")}
+
+		NewError := tf.Function(t, func() error {
+			return custom
+		})
+
+		NewError().Errors(custom)
+	})
 }
 
 type Item struct {


### PR DESCRIPTION
Solves #1.
Some refactoring to basic `Returns`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/tf/12)
<!-- Reviewable:end -->
